### PR TITLE
Add 4:3 (Preserved) & 16:9 (Preserved) aspect ratios

### DIFF
--- a/Core/EmulationSettings.cpp
+++ b/Core/EmulationSettings.cpp
@@ -49,6 +49,8 @@ double EmulationSettings::GetAspectRatio(shared_ptr<Console> console)
 		case VideoAspectRatio::PAL: return 9440000.0 / 6384411.0;
 		case VideoAspectRatio::Standard: return 4.0 / 3.0;
 		case VideoAspectRatio::Widescreen: return 16.0 / 9.0;
+		case VideoAspectRatio::StandardS: return 4.0 / 3.0;
+		case VideoAspectRatio::WidescreenS: return 16.0 / 9.0;
 		case VideoAspectRatio::Custom: return _customAspectRatio;
 	}
 	return 0.0;

--- a/Core/EmulationSettings.h
+++ b/Core/EmulationSettings.h
@@ -183,7 +183,9 @@ enum class VideoAspectRatio
 	PAL = 3,
 	Standard = 4,
 	Widescreen = 5,
-	Custom = 6
+	Custom = 6,
+	StandardS = 7,
+	WidescreenS = 8
 };
 
 struct OverscanDimensions
@@ -1232,6 +1234,14 @@ public:
 	}
 
 	double GetAspectRatio(shared_ptr<Console> console);
+	bool GetStaticAspectRatio()
+	{
+		if(_aspectRatio == VideoAspectRatio::StandardS || _aspectRatio == VideoAspectRatio::WidescreenS) {
+			return true; 
+		} else {
+			return false;
+		}
+	}
 	void InitializeInputDevices(GameInputType inputType, GameSystem system, bool silent);
 
 	void SetVideoScale(double scale)

--- a/Libretro/LibretroRenderer.h
+++ b/Libretro/LibretroRenderer.h
@@ -60,7 +60,11 @@ public:
 		if(ratio == 0.0f) {
 			ratio = (float)256 / 240;
 		}
-		ratio *= (float)_console->GetSettings()->GetOverscanDimensions().GetScreenWidth() / _console->GetSettings()->GetOverscanDimensions().GetScreenHeight() / 256 * 240;
+
+		bool staticar = (bool)_console->GetSettings()->GetStaticAspectRatio();
+		if(!staticar) {
+			ratio *= (float)_console->GetSettings()->GetOverscanDimensions().GetScreenWidth() / _console->GetSettings()->GetOverscanDimensions().GetScreenHeight() / 256 * 240;
+		}
 
 		if(_console->GetSettings()->GetScreenRotation() % 180) {
 			info.geometry.aspect_ratio = ratio == 0.0f ? 0.0f : 1.0f / ratio;

--- a/Libretro/libretro.cpp
+++ b/Libretro/libretro.cpp
@@ -162,7 +162,7 @@ extern "C" {
 			{ MesenOverscanRight, "Right Overscan; None|4px|8px|12px|16px" },
 			{ MesenOverscanTop, "Top Overscan; None|4px|8px|12px|16px" },
 			{ MesenOverscanBottom, "Bottom Overscan; None|4px|8px|12px|16px" },
-			{ MesenAspectRatio, "Aspect Ratio; Auto|No Stretching|NTSC|PAL|4:3|16:9" },
+			{ MesenAspectRatio, "Aspect Ratio; Auto|No Stretching|NTSC|PAL|4:3|4:3 (Preserved)|16:9|16:9 (Preserved)" },
 			{ MesenControllerTurboSpeed, "Controller Turbo Speed; Fast|Very Fast|Disabled|Slow|Normal" },
 			{ MesenShiftButtonsClockwise, u8"Shift A/B/X/Y clockwise; disabled|enabled" },
 			{ MesenHdPacks, "Enable HD Packs; enabled|disabled" },
@@ -486,8 +486,12 @@ extern "C" {
 			} else if(value == "PAL") {
 				_console->GetSettings()->SetVideoAspectRatio(VideoAspectRatio::PAL, 1.0);
 			} else if(value == "4:3") {
+				_console->GetSettings()->SetVideoAspectRatio(VideoAspectRatio::StandardS, 1.0);
+			} else if(value == "4:3 (Preserved)") {
 				_console->GetSettings()->SetVideoAspectRatio(VideoAspectRatio::Standard, 1.0);
 			} else if(value == "16:9") {
+				_console->GetSettings()->SetVideoAspectRatio(VideoAspectRatio::WidescreenS, 1.0);
+			} else if(value == "16:9 (Preserved)") {
 				_console->GetSettings()->SetVideoAspectRatio(VideoAspectRatio::Widescreen, 1.0);
 			}
 		}


### PR DESCRIPTION
Mesen by default preserves the aspect ratio in all cases when cropping the overscan, which results in a difference between the core provided 4:3 and 16:9 ARs, and RetroArch's own 4:3 and 16:9 ARs, which doesn't always results in a ideal image (specifically 16:9 on a 16:9 display will look weird when cropping is applied).
This PR separates Mesen's preserved 4:3 and 16:9 ARs into their own selections for the core provided aspect ratio so people can choose whenever or not they want the aspect ratio to be preserved when using either one of the selections as their core provided aspect ratio.