### PR TITLE
Use audio batch callback only once per frame

### DIFF
--- a/Core/SoundMixer.h
+++ b/Core/SoundMixer.h
@@ -33,6 +33,9 @@ private:
 	static constexpr uint32_t MaxChannelCount = 11;
 
 	retro_audio_sample_batch_t _sendAudioSample = nullptr;
+	vector<int16_t> _audioSampleBuffer;
+	size_t _audioSampleBufferPos = 0;
+
 	bool _skipMode = false;
 	EmulationSettings* _settings;
 	shared_ptr<WaveRecorder> _waveRecorder;
@@ -95,6 +98,7 @@ public:
 	void Reset();
 	
 	void PlayAudioBuffer(uint32_t cycle);
+	void UploadAudioSamples();
 	void AddDelta(AudioChannel channel, uint32_t time, int16_t delta);
 
 	void StartRecording(string filepath);

--- a/Libretro/libretro.cpp
+++ b/Libretro/libretro.cpp
@@ -48,7 +48,7 @@ static bool _hdPacksEnabled = false;
 static string _mesenVersion = "";
 static int32_t _saveStateSize = -1;
 static bool _shiftButtonsClockwise = false;
-static int32_t _audioSampleRate = 44100;
+static int32_t _audioSampleRate = 48000;
 
 //Include game database as a byte array (representing the MesenDB.txt file)
 #include "MesenDB.inc"
@@ -171,7 +171,7 @@ extern "C" {
 			{ MesenRamState, "Default power-on state for RAM; All 0s (Default)|All 1s|Random Values" },
 			{ MesenFdsAutoSelectDisk, "FDS: Automatically insert disks; disabled|enabled" },
 			{ MesenFdsFastForwardLoad, "FDS: Fast forward while loading; disabled|enabled" },
-			{ MesenAudioSampleRate, "Sound Output Sample Rate; 96000|192000|384000|11025|22050|44100|48000" },
+			{ MesenAudioSampleRate, "Sound Output Sample Rate; 48000|96000|11025|22050|44100" },
 			{ NULL, NULL },
 		};
 
@@ -557,6 +557,7 @@ extern "C" {
 			int old_value = _audioSampleRate;
 
 			_audioSampleRate = atoi(var.value);
+			_audioSampleRate = (_audioSampleRate > 96000) ? 96000 : _audioSampleRate;
 
 			if(old_value != _audioSampleRate) {
 				_console->GetSettings()->SetSampleRate(_audioSampleRate);
@@ -700,6 +701,8 @@ extern "C" {
 			_renderer->GetSystemAudioVideoInfo(avInfo);
 			retroEnv(RETRO_ENVIRONMENT_SET_GEOMETRY, &avInfo);
 		}
+
+		_console->GetSoundMixer()->UploadAudioSamples();
 	}
 
 	RETRO_API size_t retro_serialize_size()


### PR DESCRIPTION
At present, the core uploads audio by using the audio batch callback multiple times per frame, unduly 'stressing' the frontend audio buffer and leading to poor AV synchronisation.

This PR ensures that the audio batch callback is only used once per frame (unless the frontend does not support batches of sufficient size, in which case the samples will be split appropriately).

The PR also:

- Sets the default audio sample rate to 48000 Hz. The previous default of 96000 Hz is so high that RetroArch is required to flush the audio driver twice per frame, which is bad for AV synchronisation.
- Removes the 192000 and 384000 sample rate options, since these are in fact unsupported by the underlying emulator code...
