### PR TITLE
Updated README.md to remove the parts about the abandoned standalone …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,21 @@
 # Mesen
 
-Mesen is a cross-platform NES/Famicom emulator for Windows & Linux built in C++ and C#.
-
-If you want to support this project, please consider making a donation:
-
-[![Donate](https://www.mesen.ca/images/donate.png)](https://www.mesen.ca/Donate.php)
+Mesen is a cross-platform libretro core for NES/Famicom built in C++.  [Older standalone versions](https://github.com/SourMesen/Mesen/releases) are available elsewhere.
 
 [Website (https://www.mesen.ca)](https://www.mesen.ca)  
-[Documentation (https://www.mesen.ca/docs)](https://www.mesen.ca/docs)
+[Documentation](https://docs.libretro.com/library/mesen/)
 
 ## Development Builds
 
-Development builds of the latest commit are available from Appveyor. For stable release builds, see the **Releases** section below.
+Development builds of the latest commit are available from the libretro buildbot.
 
-**Warning:** These are development builds and may be ***unstable***. Using them may also increase the chances of your settings being corrupted, or having issues when upgrading to the next official release. Additionally, these builds are currently not optimized via PGO and will typically run 20-30% slower than the official release builds.
-
-Windows: [![Build status](https://ci.appveyor.com/api/projects/status/d4i7rqbfi386wdyw/branch/master?svg=true)](https://ci.appveyor.com/project/Sour/mesen/build/artifacts)
-
-Linux: [![Build status](https://ci.appveyor.com/api/projects/status/uuoxwu7o5kkqjp4e/branch/master?svg=true)](https://ci.appveyor.com/project/Sour/mesen-nyf7v/build/artifacts)
-
-## Releases
-
-### Windows
-
-The latest version is available on the [website](https://www.mesen.ca).  Older releases are available from the [releases tab on GitHub](https://github.com/SourMesen/Mesen/releases).
-
-### Ubuntu
-
-The official releases (same downloads as the Windows builds above) also contain the Linux version of Mesen, built under Ubuntu 16 - you should be able to use that in most cases if you are using Ubuntu.
-
-The Linux version is a standard .NET executable file and requires Mono to run - you may need to configure your environment to allow it to automatically run .exe files through Mono, or manually run Mesen by using mono (e.g: "mono Mesen.exe").
-
-The following packages need to be installed to run Mesen:
-
-* mono-complete
-* libsdl2-2.0
-* gnome-themes-standard
-
-**Note:** **Mono 5.18 or higher is recommended**, some older versions of Mono (e.g 4.2.2) have some stability and performance issues which can cause crashes and slow down the UI.
-The default Mono version in Ubuntu 18.04 is 4.6.2 (which also causes some layout issues in Mesen).  To install the latest version of Mono, follow the instructions here: https://www.mono-project.com/download/stable/#download-lin
-
-### Arch Linux
-
-Packages are available here: <https://aur.archlinux.org/packages/mesen>
+**Warning:** These are development builds and may be ***unstable***.
 
 ## Roadmap
 
 Things that ***may or may not*** be added in the future, in no particular order:
 
 * Support for more UNIF boards and more NES/Famicom input devices
-* Shaders
-* TAS editor
 
 ## Compiling
 


### PR DESCRIPTION
…version

Unfortunately, I can't change the repo's description, so it would be nice if you guys do that:  this is a libretro core without a standalone version and is available on many more platforms than Windows and Linux.