### PR TITLE
Move _console and _keyManager initialization to fix libretro initialization

### DIFF
--- a/Libretro/libretro.cpp
+++ b/Libretro/libretro.cpp
@@ -210,7 +210,7 @@ extern "C" {
 			{ "Standard Controller", DEVICE_GAMEPAD },
 			{ NULL, 0 },
 		};
-		
+
 		static constexpr struct retro_controller_description pads5[] = {
 			{ "Auto",     RETRO_DEVICE_JOYPAD },
 			{ "Arkanoid", DEVICE_ARKANOID },
@@ -224,10 +224,10 @@ extern "C" {
 			{ "Konami Hypershot", DEVICE_KONAMIHYPERSHOT },
 			{ "Pachinko", DEVICE_PACHINKO },
 			{ "Partytap", DEVICE_PARTYTAP },
-			{ "Oeka Kids Tablet", DEVICE_OEKAKIDS },			
+			{ "Oeka Kids Tablet", DEVICE_OEKAKIDS },
 			{ NULL, 0 },
 		};
-		
+
 		static constexpr struct retro_controller_info ports[] = {
 			{ pads1, 7 },
 			{ pads2, 7 },
@@ -266,7 +266,7 @@ extern "C" {
 	}
 
 	RETRO_API void retro_set_input_poll(retro_input_poll_t pollInput)
-	{	
+	{
 		_keyManager->SetPollInput(pollInput);
 	}
 
@@ -371,7 +371,7 @@ extern "C" {
 				_console->GetSettings()->SetAudioFilterSettings(settings);
 			}
 		}
-		
+
 		if(readVariable(MesenNtscFilter, var)) {
 			string value = string(var.value);
 			if(value == "Disabled") {
@@ -502,7 +502,7 @@ extern "C" {
 				_console->GetSettings()->SetNesModel(NesModel::Dendy);
 			}
 		}
-		
+
 		if(readVariable(MesenRamState, var)) {
 			string value = string(var.value);
 			if(value == "All 0s (Default)") {
@@ -713,7 +713,7 @@ extern "C" {
 	{
 		std::stringstream ss;
 		_console->GetSaveStateManager()->SaveState(ss);
-		
+
 		string saveStateData = ss.str();
 		memset(data, 0, size);
 		memcpy(data, saveStateData.c_str(), std::min(size, saveStateData.size()));
@@ -1032,7 +1032,7 @@ extern "C" {
 
 		_console->GetSettings()->SetFlagState(EmulationFlags::HasFourScore, hasFourScore);
 	}
-	
+
 	void retro_set_memory_maps()
 	{
 		//Expose internal RAM and work/save RAM for retroachievements
@@ -1201,7 +1201,7 @@ extern "C" {
 			case VideoFilterType::BisqwitNtsc: hscale = 8; break;
 			default: hscale = 1; break;
 		}
-		
+
 		shared_ptr<HdPackData> hdData = _console->GetHdData();
 		if(hdData) {
 			hscale = hdData->Scale;

--- a/Libretro/libretro.cpp
+++ b/Libretro/libretro.cpp
@@ -113,10 +113,6 @@ extern "C" {
 		else
 			logCallback = nullptr;
 
-		_console.reset(new Console());
-		_console->Init(env_cb);
-
-		_keyManager.reset(new LibretroKeyManager(_console));
 		_messageManager.reset(new LibretroMessageManager(logCallback, env_cb));
 
 		std::stringstream databaseData;
@@ -145,6 +141,11 @@ extern "C" {
 	RETRO_API void retro_set_environment(retro_environment_t env)
 	{
 		env_cb = env;
+
+		_console.reset(new Console());
+		_console->Init(env_cb);
+
+		_keyManager.reset(new LibretroKeyManager(_console));
 
 		static constexpr struct retro_variable vars[] = {
 			{ MesenNtscFilter, "NTSC filter; Disabled|Composite (Blargg)|S-Video (Blargg)|RGB (Blargg)|Monochrome (Blargg)|Bisqwit 2x|Bisqwit 4x|Bisqwit 8x" },


### PR DESCRIPTION
In Kodi (game.libretro add-on) we call

```
retro_set_environment
retro_set_video_refresh
retro_set_audio_sample
retro_set_audio_sample_batch
retro_set_input_poll
retro_set_input_state
```
then call
```
retro_init
```

This causes an issues because _console isn't initialized until `retro_init` but we try to access it in `retro_set_video_refresh`. This PR makes sure `_console` (and `_keyManager` needed in input callbacks) are available when setting the callbacks.

The libretro api states:
```
 /* Sets callbacks. retro_set_environment() is guaranteed to be called
 * before retro_init().
 *
 * The rest of the set_* functions are guaranteed to have been called
 * before the first call to retro_run() is made. */
```
https://github.com/libretro/libretro-common/blob/master/include/libretro.h#L3860-L3870

This is the only core that we have noticed any breakage here as it expects the call order to be
```
retro_set_environment
retro_init
retro_set_video_refresh
retro_set_audio_sample
retro_set_audio_sample_batch
retro_set_input_poll
retro_set_input_state
```

I also made an alternative approach here but it's a bit more involved (and not really any better) -> https://github.com/lrusak/Mesen/commit/fa59426d7a93571fbc659315c789191a14441261